### PR TITLE
unload controllers when pages are deleted to improve memory footprint

### DIFF
--- a/PunchScrollView.m
+++ b/PunchScrollView.m
@@ -385,6 +385,7 @@
     for (UIViewController *vc in controllerViewsToDelete)
     {
         [visiblePages_ removeObject:vc.view];
+        [pageController_ removeObject:vc];
         [vc.view removeFromSuperview];
         [vc viewDidUnload];
         vc.view = nil;

--- a/PunchScrollView.podspec
+++ b/PunchScrollView.podspec
@@ -1,0 +1,16 @@
+Pod::Spec.new do |s|
+  s.name     = 'PunchScrollView'
+  s.version  = '1.0.0'
+  s.summary  = 'PunchScrollView is a iOS ScrollView framework which works like the UITableView.'
+  s.homepage = 'https://github.com/tapwork/PunchScrollView'
+  s.author   = { 'Christian Menschel' => 'http://www.tapwork.de' }
+
+  # TODO please add a license
+  s.license  = 'UNKNOWN!'
+
+  s.source   = { :git => 'https://github.com/blazingcloud/PunchScrollView.git' }
+
+  s.platform = :ios
+  s.source_files = 'PunchScrollView.{h,m}'
+
+end


### PR DESCRIPTION
For us, it was crashing due to memory issues when we were trying to scroll through a bunch of images (50+).   